### PR TITLE
Feat: "수정 UserDetailsImpl 클래스"

### DIFF
--- a/src/main/java/com/example/springsecurity/controller/HomeController.java
+++ b/src/main/java/com/example/springsecurity/controller/HomeController.java
@@ -42,7 +42,7 @@ public class HomeController {
         if (userDetails != null) {
             model.addAttribute("username", userDetails.getUsername());
 
-            if (userDetails.getUser().getRole() == MemberRoleEnum.ADMIN) {
+            if (userDetails.getRole() == MemberRoleEnum.ADMIN) {
                 model.addAttribute("admin_role", true);
                 return "indexAdmin";
             }

--- a/src/main/java/com/example/springsecurity/controller/MemberController.java
+++ b/src/main/java/com/example/springsecurity/controller/MemberController.java
@@ -23,19 +23,19 @@ public class MemberController {
     }
 
     //ID 중복 검사
-    @PostMapping("api/member/id/check")
+    @PostMapping("/api/member/id/check")
     public ResponseEntity<?> duplicateCheckMemberId(@RequestBody DuplicateCheckMemberIdRequest duplicateCheckMemberIdRequest) {
         return memberService.duplicateCheckMemberId(duplicateCheckMemberIdRequest);
     }
 
     //닉네임 중복 검사
-    @PostMapping("api/member/nickname/check")
+    @PostMapping("/api/member/nickname/check")
     public ResponseEntity<?> duplicateCheckMemberNickname(@RequestBody DuplicateCheckMemberNicknameRequest duplicateCheckMemberNicknameRequest) {
         return memberService.duplicateCheckMemberNickname(duplicateCheckMemberNicknameRequest);
     }
 
     //로그인
-    @PostMapping("api/member/login")
+    @PostMapping("/api/member/login")
     public ResponseEntity<?> memberLogin(@RequestBody MemberLoginRequest memberLoginRequest) {
         return memberService.memberLogin(memberLoginRequest);
     }

--- a/src/main/java/com/example/springsecurity/security/UserDetailsImpl.java
+++ b/src/main/java/com/example/springsecurity/security/UserDetailsImpl.java
@@ -1,6 +1,5 @@
 package com.example.springsecurity.security;
 
-import com.example.springsecurity.entity.Member;
 import com.example.springsecurity.entity.MemberRoleEnum;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -11,26 +10,23 @@ import java.util.Collection;
 
 public class UserDetailsImpl implements UserDetails {
 
-    private final Member member;
-//    private Long id;
-//    private String nickname;
-//    private UserRoleEnum role;
+    private final String memberId;
+    private final String password;
+    private final MemberRoleEnum role;
 
-    public UserDetailsImpl(Member member) {
-        this.member = member;
+    public UserDetailsImpl(String memberId, String password, MemberRoleEnum role) {
+        this.memberId = memberId;
+        this.password = password;
+        this.role = role;
     }
 
-    public Member getUser() {
-        return member;
-    }
-
-    public String getNickname() {
-        return member.getNickname();
+    public MemberRoleEnum getRole() {
+        return role;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        MemberRoleEnum role = member.getRole();
+        MemberRoleEnum role = getRole();
         String authority = role.getAuthority();
 
         SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
@@ -42,12 +38,12 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public String getPassword() {
-        return member.getPassword();
+        return password;
     }
 
     @Override
     public String getUsername() {
-        return member.getMemberId();
+        return memberId;
     }
 
     @Override

--- a/src/main/java/com/example/springsecurity/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/springsecurity/security/UserDetailsServiceImpl.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Service
 public class UserDetailsServiceImpl implements UserDetailsService {
@@ -16,8 +18,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String MemberId) throws UsernameNotFoundException {
-        Member member = memberRepository.findByMemberId(MemberId).orElseThrow(
-                ()-> new UsernameNotFoundException("등록되지 않았거나 탈퇴한 사용자 입니다"));
-        return new UserDetailsImpl(member);
+        Optional<Member> findMember = memberRepository.findByMemberId(MemberId);
+        if (!findMember.isPresent()) {
+            throw new UsernameNotFoundException("존재하지 않는 사용자 입니다.");
+        }
+        return new UserDetailsImpl(findMember.get().getMemberId(), findMember.get().getPassword() ,findMember.get().getRole());
     }
 }

--- a/src/main/java/com/example/springsecurity/security/webSecurityConfig.java
+++ b/src/main/java/com/example/springsecurity/security/webSecurityConfig.java
@@ -56,6 +56,8 @@ public class webSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/members/**").permitAll()
                 .antMatchers("/images/**").permitAll()
                 .antMatchers("/css/**").permitAll()
+                .antMatchers("/api/member/signup").permitAll()
+                .antMatchers("/api/member/login").permitAll()
                 // '/admin'의 경우 ADMIN 권한이 있는 사용자만 접근이 가능
 //                .antMatchers("/admin").hasRole("ADMIN")
 


### PR DESCRIPTION
- 기존의 member객체를 통해서 생성

문제점 : 불피요하게 memberDB를 다시 조회한다

해결방안 : UserDetailsServiceImpl에서 loadUserByUsername를 통해 검사후 member객체가 아닌 필요한 정보만을 받아 UserDetailsImpl를 생성

해결 : memberId, password, role만을 받아 생성